### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-access-approval",
     "distribution_name": "google-cloud-access-approval",
     "api_id": "accessapproval.googleapis.com",
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,15 @@
 {
-  "name": "accessapproval",
-  "name_pretty": "Access Approval",
-  "product_documentation": "https://cloud.google.com/access-approval",
-  "client_documentation": "https://googleapis.dev/python/accessapproval/latest",
-  "issue_tracker": "",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-access-approval",
-  "distribution_name": "google-cloud-access-approval",
-  "api_id": "accessapproval.googleapis.com"
+    "name": "accessapproval",
+    "name_pretty": "Access Approval",
+    "product_documentation": "https://cloud.google.com/access-approval",
+    "client_documentation": "https://googleapis.dev/python/accessapproval/latest",
+    "issue_tracker": "",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-access-approval",
+    "distribution_name": "google-cloud-access-approval",
+    "api_id": "accessapproval.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs. 

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114