### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "accessapproval",
     "name_pretty": "Access Approval",
     "product_documentation": "https://cloud.google.com/access-approval",
-    "client_documentation": "https://googleapis.dev/python/accessapproval/latest",
+    "client_documentation": "http://cloud.google.com/python/docs/reference/accessapproval/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.