### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "accessapproval",
     "name_pretty": "Access Approval",
     "product_documentation": "https://cloud.google.com/access-approval",
-    "client_documentation": "https://googleapis.dev/python/accessapproval/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/accessapproval/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Access Approval API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-access-approval.svg
    :target: https://pypi.org/project/google-cloud-access-approval/
 .. _Access Approval API: https://cloud.google.com/access-approval
-.. _Client Library Documentation: https://googleapis.dev/python/accessapproval/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/accessapproval/latest
 .. _Product Documentation:  https://cloud.google.com/access-approval
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.