### PR TITLE
ci: use release-please for v0 branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,6 @@
 releaseType: python
 handleGHRelease: true
+branches:
+  - branch: v0
+    handleGHRelease: true
+    releaseType: python

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,6 @@
 releaseType: python
 handleGHRelease: true
+branches:
+  branch: v0
+  handleGHRelease: true
+  releaseType: python

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,6 +1,2 @@
 releaseType: python
 handleGHRelease: true
-branches:
-  branch: v0
-  handleGHRelease: true
-  releaseType: python


### PR DESCRIPTION
Copied from https://github.com/googleapis/python-storage/pull/706.